### PR TITLE
Add shared-disk-failover to regex pattern with list of ignored section

### DIFF
--- a/newrelic_marklogic_plugin/__init__.py
+++ b/newrelic_marklogic_plugin/__init__.py
@@ -290,7 +290,7 @@ class RunPlugin:
                                 metrics["Component/databases/" + db + "/cache/" + dcd + "[" + cache_units + "]"] = \
                                     database_cache_details[dcd]["value"]
                     elif re.match(
-                            "local-disk-failover|database-replication-status|flexible-replication-enabled|cpf-enabled",
+                            "local-disk-failover|database-replication-status|flexible-replication-enabled|cpf-enabled|shared-disk-failover",
                             dd):
                         log.debug("ignoring " + dd)
                     elif not units:


### PR DESCRIPTION
Unless hierarchy is handled better, it will produce an invalid NewRelic payload. Ignore shared-disk-failover for now.